### PR TITLE
Upgrade to PostgreSQL18

### DIFF
--- a/db/docker/Dockerfile
+++ b/db/docker/Dockerfile
@@ -1,7 +1,7 @@
-FROM postgres:17
+FROM postgres:18
 
 # Install pg_cron package
 RUN apt-get update && \
-    apt-get -y install postgresql-17-cron && \
+    apt-get -y install postgresql-18-cron && \
     rm -rf /var/lib/apt/lists/*
 

--- a/db/scripts/v7_add_deletion_cron.sql
+++ b/db/scripts/v7_add_deletion_cron.sql
@@ -1,6 +1,9 @@
 CREATE EXTENSION IF NOT EXISTS pg_cron;
 
-SELECT cron.unschedule('remove_deleted_users');
+SELECT cron.unschedule(jobid)
+FROM cron.job
+WHERE jobname = 'remove_deleted_users';
+
 SELECT cron.schedule(
     'remove_deleted_users',
     -- schedule: every day at midnight

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - ${POSTGRES_PORT}:${POSTGRES_PORT}
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
 
   liquibase:
     image: liquibase/liquibase


### PR DESCRIPTION
Update to psql18 for compatibility with Sideburn's staging environment.
After merging this in, you will need to remove and rebuild your `db` container and volume

Note: the pgdata volume moved in version 18. It used to be `/var/lib/postgresql/data` but is now `/var/lib/postgresql`. This is what was causing the restart loop that had us pin to version 17.
https://hub.docker.com/_/postgres#pgdata
