### PR TITLE
Delete Confirmations

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -266,6 +266,7 @@
     "editShift": "Edit Shift",
     "addShift": "Add Shift",
     "deleteShift": "Delete Shift",
+    "deleteShiftConfirmation": "Are you sure you want to delete this shift? This action cannot be undone.",
     "title": "Title of Shift",
     "titleDescription": "Description",
     "titlePlaceholder": "Title",

--- a/messages/en.json
+++ b/messages/en.json
@@ -291,7 +291,8 @@
   },
   "QualificationDetails": {
     "delete": "Delete Qualification",
-    "edit": "Edit Qualification"
+    "edit": "Edit Qualification",
+    "deleteConfirmation": "Are you sure you want to delete the qualification \"{qualificationName}\"? This will remove the qualification from all volunteers and shifts. This action cannot be undone."
   },
   "QualificationDialog": {
     "edit": "Edit Qualification",

--- a/src/app/event/[eventSlug]/team/[teamSlug]/shifts/page.tsx
+++ b/src/app/event/[eventSlug]/team/[teamSlug]/shifts/page.tsx
@@ -56,7 +56,7 @@ export default async function TeamShifts({ params }: Props) {
 
   const onSaveShift = async (data: FormData) => {
     'use server';
-    console.log('Saving shift with data:', Object.fromEntries(data.entries()));
+    console.info('Saving shift with data:', Object.fromEntries(data.entries()));
     await checkAuthorisation(editorRoles);
     const shift = validateNewShift(data);
     const shiftId = data.get('id')?.toString();
@@ -70,18 +70,16 @@ export default async function TeamShifts({ params }: Props) {
     redirect(path);
   };
 
-  const onDeleteShift = async (data: FormData) => {
+  const onDeleteShift = async (shiftId: ShiftId) => {
     'use server';
-    console.log('Deleting shift with data:', Object.fromEntries(data.entries()));
+    console.info('Deleting shiftId: ', shiftId);
     await checkAuthorisation(editorRoles);
-    const shiftId = data.get('id')?.toString();
     if (!shiftId) {
       throw new Error('Shift id is required for deletion');
     }
     await deleteShift(shiftId);
     const path = getTeamShiftsPath(eventSlug, teamSlug);
     revalidatePath(path);
-    redirect(path);
   };
 
   return (

--- a/src/ui/delete-button/index.tsx
+++ b/src/ui/delete-button/index.tsx
@@ -8,7 +8,7 @@
 
 import { Button, ButtonProps, Dialog, Flex } from '@radix-ui/themes';
 import { TrashIcon } from '@radix-ui/react-icons';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 
 type Props = {

--- a/src/ui/delete-button/index.tsx
+++ b/src/ui/delete-button/index.tsx
@@ -6,18 +6,26 @@
 
 'use client';
 
-import { Button, Dialog, Flex } from '@radix-ui/themes';
+import { Button, ButtonProps, Dialog, Flex } from '@radix-ui/themes';
 import { TrashIcon } from '@radix-ui/react-icons';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { useTranslations } from 'next-intl';
 
-interface Props {
+type Props = {
   title: string;
   description: string;
   onDelete: () => Promise<void>;
-}
+  withText?: boolean;
+} & Pick<ButtonProps, 'variant' | 'color'>;
 
-export default function DeleteButton({ title, description, onDelete }: Props) {
+export default function DeleteButton({
+  title,
+  description,
+  onDelete,
+  variant = 'outline',
+  color = 'red',
+  withText = false
+}: Props) {
   const t = useTranslations('DeleteButton');
   const [confirming, setConfirming] = useState(false);
 
@@ -30,13 +38,14 @@ export default function DeleteButton({ title, description, onDelete }: Props) {
     <Dialog.Root open={confirming} onOpenChange={setConfirming}>
       <Dialog.Trigger>
         <Button
-          variant="outline"
-          color="red"
+          variant={variant}
+          color={color}
           aria-label={title}
           title={title}
           onClick={() => setConfirming(true)}
         >
           <TrashIcon />
+          {withText && title}
         </Button>
       </Dialog.Trigger>
       <Dialog.Content>

--- a/src/ui/delete-button/index.tsx
+++ b/src/ui/delete-button/index.tsx
@@ -37,13 +37,7 @@ export default function DeleteButton({
   return (
     <Dialog.Root open={confirming} onOpenChange={setConfirming}>
       <Dialog.Trigger>
-        <Button
-          variant={variant}
-          color={color}
-          aria-label={title}
-          title={title}
-          onClick={() => setConfirming(true)}
-        >
+        <Button variant={variant} color={color} aria-label={title} title={title}>
           <TrashIcon />
           {withText && title}
         </Button>

--- a/src/ui/qualification-details/index.test.tsx
+++ b/src/ui/qualification-details/index.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import QualificationDetails from './index';
 import QualificationCard from '../qualification-card';
 import QualificationDialog from '../qualification-dialog';
+import DeleteButton from '@/ui/delete-button';
 
 jest.mock('next-intl', () => ({
   useTranslations: () => (key: string) => key,
@@ -11,6 +12,7 @@ jest.mock('next-intl', () => ({
 
 jest.mock('../qualification-card', () => jest.fn(() => <div>Mocked QualificationCard</div>));
 jest.mock('../qualification-dialog', () => jest.fn(() => <div>Mocked QualificationDialog</div>));
+jest.mock('@/ui/delete-button', () => jest.fn(() => <div data-testid="delete-button"></div>));
 
 describe('QualificationDetails', () => {
   const mockQualification = {
@@ -36,6 +38,7 @@ describe('QualificationDetails', () => {
 
   const mockOnSave = jest.fn();
   const mockOnDelete = jest.fn();
+  const mockDeleteButton = DeleteButton as jest.MockedFunction<typeof DeleteButton>;
 
   it('renders QualificationCard with correct props', () => {
     render(
@@ -62,7 +65,21 @@ describe('QualificationDetails', () => {
       />
     );
 
-    expect(screen.getByText('delete')).toBeInTheDocument();
+    expect(screen.getByTestId('delete-button')).toBeInTheDocument();
+    expect(mockDeleteButton).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onDelete: mockOnDelete
+      }),
+      undefined
+    );
+  });
+
+  it('does not render delete button when onDelete is not provided', () => {
+    render(
+      <QualificationDetails qualification={mockQualification} event={mockEvent} teams={mockTeams} />
+    );
+
+    expect(screen.queryByTestId('delete-button')).not.toBeInTheDocument();
   });
 
   it('renders QualificationDialog when canEdit is true', () => {
@@ -97,5 +114,13 @@ describe('QualificationDetails', () => {
 
     fireEvent.click(screen.getByText('Mocked QualificationCard'));
     expect(QualificationDialog).toHaveBeenCalled();
+  });
+
+  it('does not render QualificationDialog when canEdit is false', () => {
+    render(
+      <QualificationDetails qualification={mockQualification} event={mockEvent} teams={mockTeams} />
+    );
+
+    expect(screen.queryByText('Mocked QualificationDialog')).not.toBeInTheDocument();
   });
 });

--- a/src/ui/qualification-details/index.test.tsx
+++ b/src/ui/qualification-details/index.test.tsx
@@ -65,20 +65,6 @@ describe('QualificationDetails', () => {
     expect(screen.getByText('delete')).toBeInTheDocument();
   });
 
-  it('calls onDelete when delete button is clicked', () => {
-    render(
-      <QualificationDetails
-        qualification={mockQualification}
-        event={mockEvent}
-        teams={mockTeams}
-        onDelete={mockOnDelete}
-      />
-    );
-
-    fireEvent.click(screen.getByText('delete'));
-    expect(mockOnDelete).toHaveBeenCalled();
-  });
-
   it('renders QualificationDialog when canEdit is true', () => {
     render(
       <QualificationDetails

--- a/src/ui/qualification-details/index.tsx
+++ b/src/ui/qualification-details/index.tsx
@@ -6,7 +6,7 @@
 
 'use client';
 
-import { Pencil2Icon, TrashIcon } from '@radix-ui/react-icons';
+import { Pencil2Icon } from '@radix-ui/react-icons';
 import QualificationCard from '../qualification-card';
 import { Flex, Button, Box } from '@radix-ui/themes';
 import { useTranslations } from 'next-intl';

--- a/src/ui/qualification-details/index.tsx
+++ b/src/ui/qualification-details/index.tsx
@@ -8,17 +8,18 @@
 
 import { Pencil2Icon, TrashIcon } from '@radix-ui/react-icons';
 import QualificationCard from '../qualification-card';
-import { Flex, Button } from '@radix-ui/themes';
+import { Flex, Button, Box } from '@radix-ui/themes';
 import { useTranslations } from 'next-intl';
 import QualificationDialog from '../qualification-dialog';
 import { useState } from 'react';
+import DeleteButton from '../delete-button';
 
 interface Props {
   qualification: QualificationInfo;
   event: EventInfo;
   teams: TeamInfo[];
   onSave?: (data: FormData) => Promise<never>;
-  onDelete?: (data: FormData) => Promise<never>;
+  onDelete?: () => Promise<never>;
 }
 
 export default function QualificationDetails({
@@ -56,13 +57,16 @@ export default function QualificationDetails({
         }
       />
       {onDelete && (
-        <form>
-          <input type="hidden" name="id" value={qualification.id} />
-          <Button variant="ghost" color="red" formAction={onDelete}>
-            <TrashIcon />
-            {t('delete')}
-          </Button>
-        </form>
+        <Box>
+          <DeleteButton
+            variant="ghost"
+            color="red"
+            onDelete={onDelete}
+            title={t('delete')}
+            description={t('deleteConfirmation', { qualificationName: qualification.name })}
+            withText
+          />
+        </Box>
       )}
       {canEdit && (
         <QualificationDialog

--- a/src/ui/shift-dialog/index.tsx
+++ b/src/ui/shift-dialog/index.tsx
@@ -11,6 +11,7 @@ import { useTranslations } from 'next-intl';
 import { EventDayTimePicker } from '../datepicker';
 import FormDialog, { FormField } from '../form-dialog';
 import { useEffect, useState } from 'react';
+import DeleteButton from '../delete-button';
 
 interface Props {
   startDate: Date;
@@ -19,8 +20,8 @@ interface Props {
   editing?: ShiftInfo;
   creating?: boolean;
   onClose?: () => void;
-  onSubmit?: (data: FormData) => Promise<never>;
-  onDelete?: (data: FormData) => Promise<never>;
+  onSubmit?: (data: FormData) => Promise<void>;
+  onDelete?: (shiftId: ShiftId) => Promise<void>;
 }
 
 export default function ShiftDialog({
@@ -33,8 +34,7 @@ export default function ShiftDialog({
   onSubmit,
   onDelete
 }: Props) {
-  const isEdit = Boolean(editing);
-  const open = creating || isEdit;
+  const open = creating || Boolean(editing);
   const t = useTranslations('ShiftDialog');
   const title = t(editing ? 'editShift' : 'addShift');
   const [currentMin, setCurrentMin] = useState<number>(editing?.minVolunteers ?? 0);
@@ -52,10 +52,18 @@ export default function ShiftDialog({
           {title}
         </Dialog.Title>
 
-        {isEdit && onDelete && (
-          <Button variant="soft" color="red" formAction={onDelete}>
-            {t('deleteShift')}
-          </Button>
+        {editing && onDelete && (
+          <DeleteButton
+            title={t('deleteShift')}
+            variant="soft"
+            color="red"
+            onDelete={async () => {
+              await onDelete(editing.id);
+              onClose && onClose();
+            }}
+            description={t('deleteShiftConfirmation')}
+            withText
+          />
         )}
 
         <Flex direction="column" gap="4" mt="6" width="100%">

--- a/src/ui/shift-list/index.tsx
+++ b/src/ui/shift-list/index.tsx
@@ -22,8 +22,8 @@ interface Props {
   shifts: ShiftInfo[];
   qualifications: QualificationInfo[];
   exportLink: string;
-  onSaveShift?: (data: FormData) => Promise<never>;
-  onDeleteShift?: (data: FormData) => Promise<never>;
+  onSaveShift?: (data: FormData) => Promise<void>;
+  onDeleteShift?: (shiftId: ShiftId) => Promise<void>;
 }
 
 export default function ShiftList({


### PR DESCRIPTION
Brought in `DeleteButton` component from PR #28 and integrated it into `ShiftsDialog` and `QualificationDetails`.
Events, Teams, and Users already had delete confirmation.