### PR TITLE
Notify Volunteers

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -203,6 +203,9 @@
     "yourShifts": "Here are the shifts you have signed up for:",
     "closing": "Thanks again and can’t wait to see you at {eventName}!"
   },
+  "NotifyEmail": {
+    "yourShifts": "Here are the shifts you have signed up for:"
+  },
 
   "AuthContainer": {
     "logo": "Logo image"

--- a/messages/en.json
+++ b/messages/en.json
@@ -9,7 +9,7 @@
     "your": "Your",
     "shifts": "Shifts",
     "totalHours": "Total Hours",
-    "signUpHere": "Sign up for a shift",
+    "signUpHere": "Sign up for a shift here",
     "upcomingShifts": "Upcoming Shifts",
     "gettingStarted": "Getting Started",
     "gettingStartedDescription": "Start by exploring volunteer roles, browsing shifts, and finding where you fit in the community. Community is built on shared effort—everyone contributes a little to create something bigger together. By showing up, you help shape a more vibrant, connected experience for everyone.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -57,7 +57,12 @@
     "VolunteersTab": {
       "title": "Volunteers",
       "shifts": "Shifts",
-      "export": "Export volunteers"
+      "export": "Export volunteers",
+      "notifyVolunteers": "Notify volunteers",
+      "emailSuccessTitle": "Emails sent",
+      "emailSuccessMessage": "Your notifications have been sent!",
+      "emailFailureTitle": "Oops",
+      "emailFailureMessage": "Something went wrong. Please try again later."
     }
   },
   "SignInPage": {
@@ -139,8 +144,8 @@
   "EventShiftsPage": {
     "title": "Shifts",
     "allShifts": "All Current Shifts",
-    "export": "Export Shifts",
-    "notifyVolunteers": "Notify Volunteers",
+    "export": "Export shifts",
+    "notifyVolunteers": "Notify volunteers",
     "emailSuccessTitle": "Emails sent",
     "emailSuccessMessage": "Your notifications have been sent!",
     "emailFailureTitle": "Oops",
@@ -148,8 +153,8 @@
   },
   "MyShiftsPage": {
     "title": "My Shifts",
-    "export": "Export Shifts",
-    "emailMyShifts": "Email Me",
+    "export": "Export shifts",
+    "emailMyShifts": "Email me",
     "emailSuccessTitle": "Email sent",
     "emailSuccessMessage": "We've sent an email with your upcoming shifts. Check your inbox soon!",
     "emailFailureTitle": "Oops",

--- a/messages/en.json
+++ b/messages/en.json
@@ -139,7 +139,12 @@
   "EventShiftsPage": {
     "title": "Shifts",
     "allShifts": "All Current Shifts",
-    "export": "Export Shifts"
+    "export": "Export Shifts",
+    "notifyVolunteers": "Notify Volunteers",
+    "emailSuccessTitle": "Emails sent",
+    "emailSuccessMessage": "Your notifications have been sent!",
+    "emailFailureTitle": "Oops",
+    "emailFailureMessage": "Something went wrong. Please try again later."
   },
   "MyShiftsPage": {
     "title": "My Shifts",
@@ -403,6 +408,13 @@
     "label": "{filled}/{total} Spots"
   },
   "SendEmailButton": {
+    "notifyAll": "Notify All Volunteers",
+    "notifyAllDescription": "This will send an email to {numEmails} volunteers in {emailContext}.",
+    "emailSubject": "Email Subject",
+    "emailBody": "Email Body",
+    "includeShifts": "Include shift details in the email",
+    "send": "Send {numEmails, plural, one {# email} other {# emails}}",
+    "cancel": "Cancel",
     "close": "Close"
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,7 +15,7 @@ import ShiftOverviewList from '@/ui/shift-overview-list';
 import { getTeamsForEvent } from '@/service/team-service';
 import { getVolunteersForShifts } from '@/service/user-service';
 import { getPermissionsProfile } from '@/utils/permissions';
-import { CheckIcon } from '@radix-ui/react-icons';
+import { ArrowRightIcon } from '@radix-ui/react-icons';
 
 const PAGE_KEY = 'DashboardPage';
 
@@ -63,14 +63,16 @@ export default async function DashboardPage() {
 
       {/* Sign Up CTA */}
       <Flex asChild justify="start">
-        <Button variant="solid" highContrast size="4" asChild>
-          <Box asChild py="6">
-            <NextLink href={getTeamsPath()}>
-              <CheckIcon width={20} height={20} />
-              {t('signUpHere')}
-            </NextLink>
-          </Box>
-        </Button>
+        <Link asChild>
+          <Button variant="solid" highContrast size="4" asChild>
+            <Box asChild py="6">
+              <NextLink href={getTeamsPath()}>
+                <ArrowRightIcon width={20} height={20} />
+                {t('signUpHere')}
+              </NextLink>
+            </Box>
+          </Button>
+        </Link>
       </Flex>
 
       {/* Upcoming Shifts list */}

--- a/src/app/shifts/page.test.tsx
+++ b/src/app/shifts/page.test.tsx
@@ -49,6 +49,10 @@ jest.mock('@/ui/search-bar', () => ({
   default: () => <div>SearchBar</div>
 }));
 
+jest.mock('@/email/template', () => ({
+  sendEmailWithTemplate: jest.fn()
+}));
+
 const mockGetCurrentEvent = getCurrentEvent as jest.MockedFunction<typeof getCurrentEvent>;
 const mockGetCurrentEventOrRedirect = getCurrentEventOrRedirect as jest.MockedFunction<
   typeof getCurrentEventOrRedirect
@@ -137,5 +141,34 @@ describe('EventShifts Page', () => {
     render(await EventShifts());
     expect(screen.getByText('Team A')).toBeInTheDocument();
     expect(screen.getByText('Team B')).toBeInTheDocument();
+  });
+
+  it('renders the Export Shifts button', async () => {
+    mockGetCurrentEvent.mockResolvedValue(mockEvent);
+    mockGetCurrentEventOrRedirect.mockResolvedValue(mockEvent);
+    mockGetShiftsForEvent.mockResolvedValue(mockShifts);
+    mockGetTeamsForEvent.mockResolvedValue(mockTeams);
+    render(await EventShifts());
+    expect(screen.getByRole('link', { name: 'export' })).toBeInTheDocument();
+  });
+
+  it('renders the Notify Volunteers button for authorised users', async () => {
+    mockGetCurrentEvent.mockResolvedValue(mockEvent);
+    mockGetCurrentEventOrRedirect.mockResolvedValue(mockEvent);
+    mockGetShiftsForEvent.mockResolvedValue(mockShifts);
+    mockGetTeamsForEvent.mockResolvedValue(mockTeams);
+    render(await EventShifts());
+    expect(screen.getByRole('button', { name: 'notifyVolunteers' })).toBeInTheDocument();
+  });
+
+  it('does not render the Notify Volunteers button for unauthorised users', async () => {
+    const { checkAuthorisation } = require('@/session');
+    checkAuthorisation.mockResolvedValue(false);
+    mockGetCurrentEvent.mockResolvedValue(mockEvent);
+    mockGetCurrentEventOrRedirect.mockResolvedValue(mockEvent);
+    mockGetShiftsForEvent.mockResolvedValue(mockShifts);
+    mockGetTeamsForEvent.mockResolvedValue(mockTeams);
+    render(await EventShifts());
+    expect(screen.queryByRole('button', { name: 'notifyVolunteers' })).not.toBeInTheDocument();
   });
 });

--- a/src/app/shifts/page.tsx
+++ b/src/app/shifts/page.tsx
@@ -1,4 +1,6 @@
+import { sendEmailWithTemplate } from '@/email/template';
 import metadata from '@/i18n/metadata';
+import { getNotifyVolunteersAction } from '@/lib/email';
 import { getShiftsForEvent } from '@/service/shift-service';
 import { getTeamsForEvent } from '@/service/team-service';
 import { getVolunteersForShifts } from '@/service/user-service';
@@ -31,22 +33,32 @@ export default async function EventShifts() {
 
   const t = await getTranslations(PAGE_KEY);
   const shifts = await getShiftsForEvent(event.id);
+  const shiftMap = Object.fromEntries(shifts.map((shift) => [shift.id, shift]));
   const shiftVolunteers = await getVolunteersForShifts(
-    shifts.map((shift) => shift.id),
+    Object.keys(shiftMap),
     getPermissionsProfile(await currentUser())
+  );
+  const shiftsByVolunteerId = Object.entries(shiftVolunteers).reduce<Record<UserId, ShiftInfo[]>>(
+    (acc, [shiftId, volunteers]) => {
+      for (const volunteer of volunteers) {
+        if (!acc[volunteer.id]) {
+          acc[volunteer.id] = [];
+        }
+        acc[volunteer.id].push(shiftMap[shiftId]);
+      }
+      return acc;
+    },
+    {}
   );
   const teams = await getTeamsForEvent(event.id);
   const allVolunteers = deduplicateBy(Object.values(shiftVolunteers).flat(), ({ id }) => id);
 
-  const doNotify = async ({
-    subject,
-    body,
-    includeShifts
-  }: EmailCustomisation): Promise<SendEmailResult> => {
-    'use server';
-    console.log('Notify all:: ', { subject, body, includeShifts });
-    return { status: 'sent' };
-  };
+  const doNotify = getNotifyVolunteersAction({
+    volunteers: allVolunteers,
+    shiftsByVolunteerId,
+    event,
+    teams
+  });
 
   return (
     <Flex direction="column" gap="6" py="4">

--- a/src/app/shifts/page.tsx
+++ b/src/app/shifts/page.tsx
@@ -1,4 +1,3 @@
-import { sendEmailWithTemplate } from '@/email/template';
 import metadata from '@/i18n/metadata';
 import { getNotifyVolunteersAction } from '@/lib/email';
 import { getShiftsForEvent } from '@/service/shift-service';
@@ -26,10 +25,11 @@ export default async function EventShifts() {
     notFound();
   }
 
-  const canNotify = await checkAuthorisation(
-    [{ type: 'admin' }, { type: 'organiser', eventId: event.id }],
-    true
-  );
+  const notifyRoles: UserRoleMatchCriteria[] = [
+    { type: 'admin' },
+    { type: 'organiser', eventId: event.id }
+  ];
+  const canNotify = await checkAuthorisation(notifyRoles, true);
 
   const t = await getTranslations(PAGE_KEY);
   const shifts = await getShiftsForEvent(event.id);
@@ -51,13 +51,17 @@ export default async function EventShifts() {
     {}
   );
   const teams = await getTeamsForEvent(event.id);
-  const allVolunteers = deduplicateBy(Object.values(shiftVolunteers).flat(), ({ id }) => id);
+  const emailableVolunteers = deduplicateBy(
+    Object.values(shiftVolunteers).flat(),
+    ({ id }) => id
+  ).filter((v) => v.email);
 
   const doNotify = getNotifyVolunteersAction({
-    volunteers: allVolunteers,
+    volunteers: emailableVolunteers,
     shiftsByVolunteerId,
     event,
-    teams
+    teams,
+    acceptedRoles: notifyRoles
   });
 
   return (
@@ -84,7 +88,7 @@ export default async function EventShifts() {
             failureMessage={t('emailFailureMessage')}
             failureTitle={t('emailFailureTitle')}
             customisable
-            numEmails={allVolunteers.length}
+            numEmails={emailableVolunteers.length}
             emailContext={event.name}
             sendEmail={doNotify}
           >

--- a/src/app/shifts/page.tsx
+++ b/src/app/shifts/page.tsx
@@ -4,10 +4,12 @@ import { getTeamsForEvent } from '@/service/team-service';
 import { getVolunteersForShifts } from '@/service/user-service';
 import { checkAuthorisation, currentUser, getCurrentEventOrRedirect } from '@/session';
 import SearchBar from '@/ui/search-bar';
+import SendEmailButton from '@/ui/send-email-button';
 import ShiftOverviewList from '@/ui/shift-overview-list';
+import { deduplicateBy } from '@/utils/list';
 import { getEventShiftsApiPath } from '@/utils/path';
 import { getPermissionsProfile } from '@/utils/permissions';
-import { Share2Icon } from '@radix-ui/react-icons';
+import { Share2Icon, EnvelopeClosedIcon } from '@radix-ui/react-icons';
 import { Button, Flex, Heading } from '@radix-ui/themes';
 import { getTranslations } from 'next-intl/server';
 import { notFound } from 'next/navigation';
@@ -17,19 +19,34 @@ const PAGE_KEY = 'EventShiftsPage';
 export const generateMetadata = metadata(PAGE_KEY);
 
 export default async function EventShifts() {
-  await checkAuthorisation();
-  const t = await getTranslations(PAGE_KEY);
   const event = await getCurrentEventOrRedirect();
   if (!event) {
     notFound();
   }
 
+  const canNotify = await checkAuthorisation(
+    [{ type: 'admin' }, { type: 'organiser', eventId: event.id }],
+    true
+  );
+
+  const t = await getTranslations(PAGE_KEY);
   const shifts = await getShiftsForEvent(event.id);
   const shiftVolunteers = await getVolunteersForShifts(
     shifts.map((shift) => shift.id),
     getPermissionsProfile(await currentUser())
   );
   const teams = await getTeamsForEvent(event.id);
+  const allVolunteers = deduplicateBy(Object.values(shiftVolunteers).flat(), ({ id }) => id);
+
+  const doNotify = async ({
+    subject,
+    body,
+    includeShifts
+  }: EmailCustomisation): Promise<SendEmailResult> => {
+    'use server';
+    console.log('Notify all:: ', { subject, body, includeShifts });
+    return { status: 'sent' };
+  };
 
   return (
     <Flex direction="column" gap="6" py="4">
@@ -47,6 +64,22 @@ export default async function EventShifts() {
             {t('export')}
           </a>
         </Button>
+        {canNotify && (
+          <SendEmailButton
+            variant="soft"
+            successMessage={t('emailSuccessMessage')}
+            successTitle={t('emailSuccessTitle')}
+            failureMessage={t('emailFailureMessage')}
+            failureTitle={t('emailFailureTitle')}
+            customisable
+            numEmails={allVolunteers.length}
+            emailContext={event.name}
+            sendEmail={doNotify}
+          >
+            <EnvelopeClosedIcon />
+            {t('notifyVolunteers')}
+          </SendEmailButton>
+        )}
       </Flex>
       <SearchBar />
       <ShiftOverviewList

--- a/src/app/team/[teamSlug]/layout.tsx
+++ b/src/app/team/[teamSlug]/layout.tsx
@@ -51,7 +51,9 @@ export default async function TeamLayout({ params, children }: Props) {
       <Heading my="4" align="center">
         {team.name}
       </Heading>
-      <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{team.description}</pre>
+      <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontFamily: 'inherit' }}>
+        {team.description}
+      </pre>
       <DataList.Root my="4">
         <DataList.Item>
           <DataList.Label>{t('contact')}</DataList.Label>

--- a/src/app/team/[teamSlug]/volunteers/page.tsx
+++ b/src/app/team/[teamSlug]/volunteers/page.tsx
@@ -15,12 +15,14 @@ import VolunteerList from '@/ui/volunteer-list';
 import { addHoursToTimeString, eventDayToDate } from '@/utils/datetime';
 import { getPermissionsProfile } from '@/utils/permissions';
 import { recordToUserFilters } from '@/utils/user-filters';
-import { Box, Button, Flex, Text } from '@radix-ui/themes';
+import { Button, Flex, Text } from '@radix-ui/themes';
 import { getTranslations } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 import NextLink from 'next/link';
 import { getTeamVolunteersApiPath } from '@/utils/path';
-import { Share2Icon } from '@radix-ui/react-icons';
+import { EnvelopeClosedIcon, Share2Icon } from '@radix-ui/react-icons';
+import SendEmailButton from '@/ui/send-email-button';
+import { getNotifyVolunteersAction } from '@/lib/email';
 
 const PAGE_KEY = 'TeamPage.VolunteersTab';
 
@@ -33,8 +35,6 @@ export const generateMetadata = metadata(PAGE_KEY, {
     return `${t('title')} | ${team?.name ?? ''}`;
   }
 });
-
-interface Props {}
 
 export default async function TeamVolunteers({
   params,
@@ -57,8 +57,8 @@ export default async function TeamVolunteers({
   filters.onTeam = team.id;
   const volunteers = await getFilteredVolunteers(filters, permissionsProfile);
   const shifts = await getShiftsForVolunteers(
-    team.eventId,
-    volunteers.map((v) => v.id)
+    volunteers.map((v) => v.id),
+    { team }
   );
 
   const shiftPanels = volunteers.reduce<Record<UserId, React.ReactNode>>((acc, volunteer) => {
@@ -66,7 +66,7 @@ export default async function TeamVolunteers({
       acc[volunteer.id] = (
         <Collapsible header={t('shifts')}>
           <DatedList
-            items={shifts[volunteer.id].filter((s) => s.teamId === team.id)}
+            items={shifts[volunteer.id]}
             getDate={(s) => eventDayToDate(event.startDate, s.eventDay)}
             renderItem={(shift) => (
               <Flex direction="column" key={`${volunteer.id}:${shift.id}`} asChild>
@@ -86,9 +86,16 @@ export default async function TeamVolunteers({
     return acc;
   }, {});
 
+  const doNotify = getNotifyVolunteersAction({
+    volunteers,
+    shiftsByVolunteerId: shifts,
+    event,
+    teams: [team]
+  });
+
   return (
     <Flex direction="column" gap="6">
-      <Box>
+      <Flex gap="2">
         <Button asChild variant="soft">
           <NextLink
             href={getTeamVolunteersApiPath(event.slug, teamSlug, { format: 'csv' })}
@@ -99,7 +106,21 @@ export default async function TeamVolunteers({
             {t('export')}
           </NextLink>
         </Button>
-      </Box>
+        <SendEmailButton
+          variant="soft"
+          successMessage={t('emailSuccessMessage')}
+          successTitle={t('emailSuccessTitle')}
+          failureMessage={t('emailFailureMessage')}
+          failureTitle={t('emailFailureTitle')}
+          customisable
+          numEmails={volunteers.length}
+          emailContext={team.name}
+          sendEmail={doNotify}
+        >
+          <EnvelopeClosedIcon />
+          {t('notifyVolunteers')}
+        </SendEmailButton>
+      </Flex>
       <VolunteerList
         volunteers={volunteers}
         withFilters={['searchQuery']}

--- a/src/app/team/[teamSlug]/volunteers/page.tsx
+++ b/src/app/team/[teamSlug]/volunteers/page.tsx
@@ -47,15 +47,17 @@ export default async function TeamVolunteers({
   if (!event || !team) {
     notFound();
   }
-  await checkAuthorisation([
+  const acceptedRoles: UserRoleMatchCriteria[] = [
     { type: 'admin' },
     { type: 'organiser', eventId: team.eventId },
     { type: 'team-lead', eventId: team.eventId, teamId: team.id }
-  ]);
+  ];
+  await checkAuthorisation(acceptedRoles);
   const permissionsProfile = getPermissionsProfile(await currentUser());
   const filters = recordToUserFilters(await searchParams);
   filters.onTeam = team.id;
   const volunteers = await getFilteredVolunteers(filters, permissionsProfile);
+  const emailableVolunteers = volunteers.filter((v) => v.email);
   const shifts = await getShiftsForVolunteers(
     volunteers.map((v) => v.id),
     { team }
@@ -87,10 +89,11 @@ export default async function TeamVolunteers({
   }, {});
 
   const doNotify = getNotifyVolunteersAction({
-    volunteers,
+    volunteers: emailableVolunteers,
     shiftsByVolunteerId: shifts,
     event,
-    teams: [team]
+    teams: [team],
+    acceptedRoles
   });
 
   return (
@@ -113,7 +116,7 @@ export default async function TeamVolunteers({
           failureMessage={t('emailFailureMessage')}
           failureTitle={t('emailFailureTitle')}
           customisable
-          numEmails={volunteers.length}
+          numEmails={emailableVolunteers.length}
           emailContext={team.name}
           sendEmail={doNotify}
         >

--- a/src/email/template/NotifyEmail.tsx
+++ b/src/email/template/NotifyEmail.tsx
@@ -70,7 +70,7 @@ export async function body(props: Props) {
   const t = await getTranslations(TEMPLATE_KEY);
   return (
     <>
-      <p>{props.body}</p>
+      <pre>{props.body}</pre>
       {props.shifts && (
         <>
           <p>{t('yourShifts')}</p>

--- a/src/email/template/NotifyEmail.tsx
+++ b/src/email/template/NotifyEmail.tsx
@@ -8,7 +8,7 @@ import { getListByDate } from '@/utils/date';
 import { addHoursToTimeString, eventDayToDate } from '@/utils/datetime';
 import { getTranslations } from 'next-intl/server';
 
-const TEMPLATE_KEY = 'ShiftEmail';
+const TEMPLATE_KEY = 'NotifyEmail';
 
 interface BaseProps {
   body: string;

--- a/src/email/template/NotifyEmail.tsx
+++ b/src/email/template/NotifyEmail.tsx
@@ -66,15 +66,15 @@ const ShiftRow = ({ shift, team }: { shift: ShiftInfo; team: TeamInfo | undefine
   </>
 );
 
-export async function body({ event, body, shifts, teams }: Props) {
+export async function body(props: Props) {
   const t = await getTranslations(TEMPLATE_KEY);
   return (
     <>
-      <p>{body}</p>
-      {shifts && (
+      <p>{props.body}</p>
+      {props.shifts && (
         <>
           <p>{t('yourShifts')}</p>
-          <ShiftList event={event} shifts={shifts} teams={teams} />
+          <ShiftList event={props.event} shifts={props.shifts} teams={props.teams} />
         </>
       )}
     </>

--- a/src/email/template/NotifyEmail.tsx
+++ b/src/email/template/NotifyEmail.tsx
@@ -1,0 +1,86 @@
+/**
+ * Email template for volunteer notification emails
+ * @since 2026-04-01
+ * @author Michael Townsend <@continuities>
+ */
+
+import { getListByDate } from '@/utils/date';
+import { addHoursToTimeString, eventDayToDate } from '@/utils/datetime';
+import { getTranslations } from 'next-intl/server';
+
+const TEMPLATE_KEY = 'ShiftEmail';
+
+interface BaseProps {
+  body: string;
+  subject: string;
+}
+
+interface PropsWithShifts extends BaseProps {
+  event: EventInfo;
+  shifts: ShiftInfo[];
+  teams: TeamInfo[];
+}
+
+interface PropsWithoutShifts extends BaseProps {
+  event?: never;
+  shifts?: never;
+  teams?: never;
+}
+
+type Props = PropsWithShifts | PropsWithoutShifts;
+
+const ShiftList = ({
+  event,
+  shifts,
+  teams
+}: {
+  event: EventInfo;
+  shifts: ShiftInfo[];
+  teams: TeamInfo[];
+}) => {
+  const teamsById = Object.fromEntries(teams.map((team) => [team.id, team]));
+  const shiftsByDate = getListByDate(shifts, (s) => eventDayToDate(event.startDate, s.eventDay));
+  return (
+    <ul>
+      {Object.entries(shiftsByDate).map(([date, shifts]) => (
+        <li key={date}>
+          <strong>{date}</strong>
+          <ul>
+            {shifts.map((shift) => (
+              <li key={shift.id}>
+                <ShiftRow shift={shift} team={teamsById[shift.teamId]} />
+              </li>
+            ))}
+          </ul>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+const ShiftRow = ({ shift, team }: { shift: ShiftInfo; team: TeamInfo | undefined }) => (
+  <>
+    {shift.title}
+    {team ? ` (${team.name})` : ''} {shift.startTime} to{' '}
+    {addHoursToTimeString(shift.startTime, shift.durationHours)}
+  </>
+);
+
+export async function body({ event, body, shifts, teams }: Props) {
+  const t = await getTranslations(TEMPLATE_KEY);
+  return (
+    <>
+      <p>{body}</p>
+      {shifts && (
+        <>
+          <p>{t('yourShifts')}</p>
+          <ShiftList event={event} shifts={shifts} teams={teams} />
+        </>
+      )}
+    </>
+  );
+}
+
+export async function subject({ subject }: Props) {
+  return subject;
+}

--- a/src/email/template/index.ts
+++ b/src/email/template/index.ts
@@ -1,10 +1,12 @@
 import type { body as ShiftEmail } from './ShiftEmail';
+import type { body as NotifyEmail } from './NotifyEmail';
 import { htmlToText } from 'html-to-text';
 import { sendEmail } from '@/email';
 import { queueEmail } from '@/service/email-service';
 
 type Templates = {
   ShiftEmail: typeof ShiftEmail;
+  NotifyEmail: typeof NotifyEmail;
 };
 
 type TemplateName = keyof Templates;

--- a/src/lib/email.test.ts
+++ b/src/lib/email.test.ts
@@ -1,0 +1,130 @@
+import { sendUserShiftEmail, getNotifyVolunteersAction } from './email';
+import { sendEmailWithTemplate } from '@/email/template';
+
+jest.mock('@/email/template', () => ({
+  sendEmailWithTemplate: jest.fn()
+}));
+
+const mockSendEmailWithTemplate = sendEmailWithTemplate as jest.MockedFunction<
+  typeof sendEmailWithTemplate
+>;
+
+describe('sendUserShiftEmail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call sendEmailWithTemplate with correct parameters', async () => {
+    const event = { slug: 'event-slug' } as EventInfo;
+    const user = { id: 'user-id', email: 'user@example.com', chosenName: 'John' } as User;
+    const shifts = [{ eventDay: 1, startTime: '10:00' }] as ShiftInfo[];
+    const teams = [{ id: 'team-id' }] as TeamInfo[];
+
+    await sendUserShiftEmail({ event, user, shifts, teams });
+
+    expect(mockSendEmailWithTemplate).toHaveBeenCalledWith({
+      key: 'ShiftEmail:event-slug:user-id',
+      to: 'user@example.com',
+      template: 'ShiftEmail',
+      props: {
+        name: 'John',
+        event,
+        shifts,
+        teams
+      }
+    });
+  });
+});
+
+describe('getNotifyVolunteersAction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('should send emails to volunteers with correct parameters', async () => {
+    const volunteers = [
+      { id: 'volunteer-1', email: 'volunteer1@example.com' },
+      { id: 'volunteer-2', email: 'volunteer2@example.com' }
+    ] as VolunteerInfo[];
+    const shiftsByVolunteerId = {
+      'volunteer-1': [{ eventDay: 1, startTime: '09:00' }] as ShiftInfo[],
+      'volunteer-2': [{ eventDay: 2, startTime: '10:00' }] as ShiftInfo[]
+    };
+    const event = { slug: 'event-slug' } as EventInfo;
+    const teams = [{ id: 'team-id' }] as TeamInfo[];
+    const emailCustomisation = {
+      subject: 'Test Subject',
+      body: 'Test Body',
+      includeShifts: true
+    };
+
+    const notifyVolunteersAction = getNotifyVolunteersAction({
+      volunteers,
+      shiftsByVolunteerId,
+      event,
+      teams
+    });
+
+    await notifyVolunteersAction(emailCustomisation);
+
+    expect(mockSendEmailWithTemplate).toHaveBeenCalledTimes(2);
+    expect(mockSendEmailWithTemplate).toHaveBeenCalledWith({
+      to: 'volunteer1@example.com',
+      template: 'NotifyEmail',
+      props: {
+        subject: 'Test Subject',
+        body: 'Test Body',
+        event,
+        shifts: [{ eventDay: 1, startTime: '09:00' }],
+        teams
+      }
+    });
+    expect(mockSendEmailWithTemplate).toHaveBeenCalledWith({
+      to: 'volunteer2@example.com',
+      template: 'NotifyEmail',
+      props: {
+        subject: 'Test Subject',
+        body: 'Test Body',
+        event,
+        shifts: [{ eventDay: 2, startTime: '10:00' }],
+        teams
+      }
+    });
+  });
+
+  it('should skip volunteers without email addresses', async () => {
+    const volunteers = [
+      { id: 'volunteer-1', email: 'volunteer1@example.com' },
+      { id: 'volunteer-2', email: null }
+    ] as VolunteerInfo[];
+    const shiftsByVolunteerId = {
+      'volunteer-1': [{ eventDay: 1, startTime: '09:00' }] as ShiftInfo[]
+    };
+    const event = { slug: 'event-slug' } as EventInfo;
+    const teams = [{ id: 'team-id' }] as TeamInfo[];
+    const emailCustomisation = {
+      subject: 'Test Subject',
+      body: 'Test Body',
+      includeShifts: false
+    };
+
+    const { getNotifyVolunteersAction } = await import('./email');
+    const notifyVolunteersAction = getNotifyVolunteersAction({
+      volunteers,
+      shiftsByVolunteerId,
+      event,
+      teams
+    });
+
+    await notifyVolunteersAction(emailCustomisation);
+
+    expect(mockSendEmailWithTemplate).toHaveBeenCalledTimes(1);
+    expect(mockSendEmailWithTemplate).toHaveBeenCalledWith({
+      to: 'volunteer1@example.com',
+      template: 'NotifyEmail',
+      props: {
+        subject: 'Test Subject',
+        body: 'Test Body'
+      }
+    });
+  });
+});

--- a/src/lib/email.test.ts
+++ b/src/lib/email.test.ts
@@ -2,7 +2,11 @@ import { sendUserShiftEmail, getNotifyVolunteersAction } from './email';
 import { sendEmailWithTemplate } from '@/email/template';
 
 jest.mock('@/email/template', () => ({
-  sendEmailWithTemplate: jest.fn()
+  sendEmailWithTemplate: jest.fn().mockResolvedValue({ status: 'sent' })
+}));
+
+jest.mock('@/session', () => ({
+  checkAuthorisation: jest.fn().mockResolvedValue(true)
 }));
 
 const mockSendEmailWithTemplate = sendEmailWithTemplate as jest.MockedFunction<
@@ -61,7 +65,8 @@ describe('getNotifyVolunteersAction', () => {
       volunteers,
       shiftsByVolunteerId,
       event,
-      teams
+      teams,
+      acceptedRoles: []
     });
 
     await notifyVolunteersAction(emailCustomisation);
@@ -112,7 +117,8 @@ describe('getNotifyVolunteersAction', () => {
       volunteers,
       shiftsByVolunteerId,
       event,
-      teams
+      teams,
+      acceptedRoles: []
     });
 
     await notifyVolunteersAction(emailCustomisation);

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -36,3 +36,44 @@ export const sendUserShiftEmail = async ({
       teams
     }
   });
+
+export const getNotifyVolunteersAction =
+  ({
+    volunteers,
+    shiftsByVolunteerId,
+    event,
+    teams
+  }: {
+    volunteers: VolunteerInfo[];
+    shiftsByVolunteerId: Record<UserId, ShiftInfo[]>;
+    event: EventInfo;
+    teams: TeamInfo[];
+  }) =>
+  async ({ subject, body, includeShifts }: EmailCustomisation): Promise<SendEmailResult> => {
+    'use server';
+    const baseProps = { subject, body };
+    volunteers
+      .filter((v) => v.email)
+      .map((volunteer) => {
+        const shifts = [...(shiftsByVolunteerId[volunteer.id] || [])].sort((a, b) => {
+          if (a.eventDay !== b.eventDay) {
+            return a.eventDay - b.eventDay;
+          }
+          return a.startTime.localeCompare(b.startTime);
+        });
+        const props = includeShifts
+          ? {
+              ...baseProps,
+              event,
+              shifts,
+              teams
+            }
+          : baseProps;
+        sendEmailWithTemplate({
+          to: volunteer.email!, // we filtered out the ones without emails
+          template: 'NotifyEmail',
+          props
+        });
+      });
+    return { status: 'sent' };
+  };

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -5,6 +5,7 @@
  */
 
 import { sendEmailWithTemplate } from '@/email/template';
+import { checkAuthorisation } from '@/session';
 
 /**
  * Send an email to a user about their volunteer shifts for an event
@@ -50,38 +51,52 @@ export const getNotifyVolunteersAction =
     volunteers,
     shiftsByVolunteerId,
     event,
-    teams
+    teams,
+    acceptedRoles
   }: {
     volunteers: VolunteerInfo[];
     shiftsByVolunteerId: Record<UserId, ShiftInfo[]>;
     event: EventInfo;
     teams: TeamInfo[];
+    acceptedRoles: UserRoleMatchCriteria[];
   }) =>
   async ({ subject, body, includeShifts }: EmailCustomisation): Promise<SendEmailResult> => {
     'use server';
+    await checkAuthorisation(acceptedRoles);
     const baseProps = { subject, body };
-    volunteers
-      .filter((v) => v.email)
-      .map((volunteer) => {
-        const shifts = [...(shiftsByVolunteerId[volunteer.id] || [])].sort((a, b) => {
-          if (a.eventDay !== b.eventDay) {
-            return a.eventDay - b.eventDay;
-          }
-          return a.startTime.localeCompare(b.startTime);
-        });
-        const props = includeShifts
-          ? {
-              ...baseProps,
-              event,
-              shifts,
-              teams
+    const results = await Promise.all(
+      volunteers
+        .filter((v) => v.email)
+        .map((volunteer) => {
+          const shifts = [...(shiftsByVolunteerId[volunteer.id] || [])].sort((a, b) => {
+            if (a.eventDay !== b.eventDay) {
+              return a.eventDay - b.eventDay;
             }
-          : baseProps;
-        sendEmailWithTemplate({
-          to: volunteer.email!, // we filtered out the ones without emails
-          template: 'NotifyEmail',
-          props
-        });
-      });
-    return { status: 'sent' };
+            return a.startTime.localeCompare(b.startTime);
+          });
+          const props = includeShifts
+            ? {
+                ...baseProps,
+                event,
+                shifts,
+                teams
+              }
+            : baseProps;
+          return sendEmailWithTemplate({
+            to: volunteer.email!, // we filtered out the ones without emails
+            template: 'NotifyEmail',
+            props
+          });
+        })
+    );
+    let successStatus: 'sent' | 'queued' = 'sent';
+    for (const r of results) {
+      if (r.status === 'failed') {
+        return r;
+      }
+      if (r.status === 'queued') {
+        successStatus = 'queued';
+      }
+    }
+    return { status: successStatus };
   };

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -37,6 +37,14 @@ export const sendUserShiftEmail = async ({
     }
   });
 
+/**
+ * Gets a server action for sending a notification email to volunteers
+ * @param param.volunteers - list of volunteers to send the email to
+ * @param param.shiftsByVolunteerId - mapping of volunteer ID to their shifts
+ * @param param.event - event info for the event the volunteers are signed up for
+ * @param param.teams - list of teams for the event (used if including shifts in the email)
+ * @returns a server action that takes email customisation options and sends the email to the volunteers
+ */
 export const getNotifyVolunteersAction =
   ({
     volunteers,

--- a/src/service/shift-service.ts
+++ b/src/service/shift-service.ts
@@ -310,10 +310,7 @@ export const deleteShift = async (shiftId: ShiftId, client?: PoolClient): Promis
  * @param shiftId - The ID of the shift to lock on
  * @param client - database client for transaction support
  */
-export const getShiftLock = async (
-  shiftId: ShiftId,
-  client: PoolClient
-): Promise<void> => {
+export const getShiftLock = async (shiftId: ShiftId, client: PoolClient): Promise<void> => {
   await client.query(`SELECT id FROM shift WHERE id = $1 FOR UPDATE`, [shiftId]);
 };
 
@@ -414,11 +411,31 @@ export const getShiftsForVolunteer = cache(
  * @return An object mapping volunteer IDs to arrays of ShiftInfo objects
  */
 export const getShiftsForVolunteers = cache(
-  async (eventId: EventId, volunteerIds: UserId[]): Promise<Record<UserId, ShiftInfo[]>> => {
+  async (
+    volunteerIds: UserId[],
+    filter: { event?: EventInfo; team?: TeamInfo }
+  ): Promise<Record<UserId, ShiftInfo[]>> => {
     if (volunteerIds.length === 0) {
       return {};
     }
-    console.info(`Fetching shifts for volunteers ${volunteerIds.join(', ')} in event ${eventId}`);
+
+    const values: any[] = [volunteerIds];
+    const filterClauses = [];
+    if (filter?.event) {
+      values.push(filter.event.id);
+      filterClauses.push(
+        `
+          AND s."teamId" IN (
+            SELECT id FROM team WHERE "eventId" = $${values.length}
+          )
+        `
+      );
+    }
+    if (filter?.team) {
+      values.push(filter.team.id);
+      filterClauses.push(`AND s."teamId" = $${values.length}`);
+    }
+
     const result = await pool.query(
       `
     SELECT 
@@ -437,12 +454,10 @@ export const getShiftsForVolunteers = cache(
     LEFT JOIN requirement r ON s.id = r."shiftId"
     JOIN shift_volunteer sv ON s.id = sv.shift_id
     WHERE sv.user_id = ANY($1)
-    AND s."teamId" IN (
-      SELECT id FROM team WHERE "eventId" = $2
-    )
+    ${filterClauses.join(' ')}
     ORDER BY s."eventDay", s."startTime"
     `,
-      [volunteerIds, eventId]
+      values
     );
     const shifts = rowsToShifts(result.rows);
     const shiftMap = new Map<ShiftId, ShiftInfo>(shifts.map((s) => [s.id, s]));

--- a/src/service/shift-service.ts
+++ b/src/service/shift-service.ts
@@ -406,8 +406,10 @@ export const getShiftsForVolunteer = cache(
 
 /**
  * Fetches a list of shifts for multiple volunteers in a given event.
- * @param eventId - The ID of the event to fetch shifts for.
  * @param volunteerIds - An array of volunteer IDs to fetch shifts for.
+ * @params filter - An object containing optional filters
+ * @params filter.event - An EventInfo object to filter shifts by event
+ * @params filter.team - A TeamInfo object to filter shifts by team
  * @return An object mapping volunteer IDs to arrays of ShiftInfo objects
  */
 export const getShiftsForVolunteers = cache(

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -12,6 +12,7 @@ declare global {
   type PagePropsWithSearch<T extends AppRoutes, S> = Omit<PageProps<T>, 'searchParams'> & {
     searchParams: Promise<S>;
   };
+  type WithRequired<T, K extends keyof T> = T & Required<Pick<T, K>>;
   type PartialWithRequired<T, R extends keyof T> = Partial<T> & Pick<T, R>;
   type OptionalKeys<T> = {
     [K in keyof T]-?: undefined extends T[K] ? K : never;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -28,6 +28,12 @@ declare global {
         error: string;
       };
 
+  interface EmailCustomisation {
+    subject: string;
+    body: string;
+    includeShifts: boolean;
+  }
+
   type UserId = string;
   type EventId = string;
   type TeamId = string;

--- a/src/ui/send-email-button/index.test.tsx
+++ b/src/ui/send-email-button/index.test.tsx
@@ -101,4 +101,100 @@ describe('SendEmailButton', () => {
     fireEvent.click(getByRole('button', { name: /close/i }));
     expect(queryByText('Success')).not.toBeInTheDocument();
   });
+
+  it('renders the customisation dialog when customisable is true', () => {
+    const { getByRole, queryByText } = render(
+      <SendEmailButton
+        sendEmail={jest.fn()}
+        successTitle="Success"
+        successMessage="Email sent successfully"
+        failureTitle="Failure"
+        failureMessage="Failed to send email"
+        customisable
+        numEmails={5}
+        emailContext="test context"
+      />
+    );
+
+    expect(queryByText('notifyAll')).not.toBeInTheDocument();
+    fireEvent.click(getByRole('button'));
+    expect(queryByText('notifyAll')).toBeInTheDocument();
+  });
+
+  it('sends a customised email and shows success dialog', async () => {
+    const sendEmailMock = jest.fn(() => Promise.resolve<SendEmailResult>({ status: 'sent' }));
+    const { getByRole, getByPlaceholderText, getByLabelText, findByText } = render(
+      <SendEmailButton
+        sendEmail={sendEmailMock}
+        successTitle="Success"
+        successMessage="Email sent successfully"
+        failureTitle="Failure"
+        failureMessage="Failed to send email"
+        customisable
+        numEmails={5}
+        emailContext="test context"
+      />
+    );
+
+    fireEvent.click(getByRole('button'));
+    fireEvent.change(getByPlaceholderText('emailSubject'), { target: { value: 'Test Subject' } });
+    fireEvent.change(getByPlaceholderText('emailBody'), { target: { value: 'Test Body' } });
+    fireEvent.click(getByRole('checkbox'));
+    fireEvent.click(getByRole('button', { name: 'send' }));
+
+    expect(await findByText('Success')).toBeInTheDocument();
+    expect(await findByText('Email sent successfully')).toBeInTheDocument();
+    expect(sendEmailMock).toHaveBeenCalledWith({
+      subject: 'Test Subject',
+      body: 'Test Body',
+      includeShifts: true
+    });
+  });
+
+  it('shows failure dialog when customised email fails', async () => {
+    const sendEmailMock = jest.fn(() =>
+      Promise.resolve<SendEmailResult>({ status: 'failed', error: 'error' })
+    );
+    const { getByRole, getByPlaceholderText, findByText } = render(
+      <SendEmailButton
+        sendEmail={sendEmailMock}
+        successTitle="Success"
+        successMessage="Email sent successfully"
+        failureTitle="Failure"
+        failureMessage="Failed to send email"
+        customisable
+        numEmails={5}
+        emailContext="test context"
+      />
+    );
+
+    fireEvent.click(getByRole('button'));
+    fireEvent.change(getByPlaceholderText('emailSubject'), { target: { value: 'Test Subject' } });
+    fireEvent.change(getByPlaceholderText('emailBody'), { target: { value: 'Test Body' } });
+    fireEvent.click(getByRole('button', { name: 'send' }));
+
+    expect(await findByText('Failure')).toBeInTheDocument();
+    expect(await findByText('Failed to send email')).toBeInTheDocument();
+  });
+
+  it('closes the customisation dialog when the cancel button is clicked', () => {
+    const { getByRole, queryByText } = render(
+      <SendEmailButton
+        sendEmail={jest.fn()}
+        successTitle="Success"
+        successMessage="Email sent successfully"
+        failureTitle="Failure"
+        failureMessage="Failed to send email"
+        customisable
+        numEmails={5}
+        emailContext="test context"
+      />
+    );
+
+    fireEvent.click(getByRole('button'));
+    expect(queryByText('notifyAll')).toBeInTheDocument();
+
+    fireEvent.click(getByRole('button', { name: /cancel/i }));
+    expect(queryByText('notifyAll')).not.toBeInTheDocument();
+  });
 });

--- a/src/ui/send-email-button/index.tsx
+++ b/src/ui/send-email-button/index.tsx
@@ -134,6 +134,7 @@ export default function SendEmailButton({
                     name="email-subject"
                     placeholder={t('emailSubject')}
                     aria-labelledby="email-subject"
+                    autoComplete="off"
                   />
                 </FormField>
                 <FormField ariaId="email-body" name={t('emailBody')}>
@@ -144,6 +145,7 @@ export default function SendEmailButton({
                     aria-labelledby="email-body"
                     size="3"
                     resize="vertical"
+                    autoComplete="off"
                   />
                 </FormField>
                 <FormField ariaId="include-shifts" name={t('includeShifts')}>

--- a/src/ui/send-email-button/index.tsx
+++ b/src/ui/send-email-button/index.tsx
@@ -146,6 +146,7 @@ export default function SendEmailButton({
                     size="3"
                     resize="vertical"
                     autoComplete="off"
+                    data-1p-ignore
                   />
                 </FormField>
                 <FormField ariaId="include-shifts" name={t('includeShifts')}>

--- a/src/ui/send-email-button/index.tsx
+++ b/src/ui/send-email-button/index.tsx
@@ -6,17 +6,33 @@
 
 'use client';
 
-import { Button, Dialog, ButtonProps, Flex } from '@radix-ui/themes';
+import { Button, Dialog, ButtonProps, Flex, TextField, TextArea, Checkbox } from '@radix-ui/themes';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
+import { FormField } from '../form-dialog';
 
-type Props = {
-  sendEmail: () => Promise<SendEmailResult>;
+type BaseProps = {
   successTitle: string;
   successMessage: string;
   failureTitle: string;
   failureMessage: string;
 } & Omit<ButtonProps, 'onClick'>;
+
+type CustomisableProps = {
+  customisable: true;
+  numEmails: number;
+  emailContext: string;
+  sendEmail: (customisation: EmailCustomisation) => Promise<SendEmailResult>;
+} & BaseProps;
+
+type NonCustomisableProps = {
+  customisable?: never;
+  numEmails?: never;
+  emailContext?: never;
+  sendEmail: () => Promise<SendEmailResult>;
+} & BaseProps;
+
+type Props = CustomisableProps | NonCustomisableProps;
 
 export default function SendEmailButton({
   sendEmail,
@@ -25,33 +41,135 @@ export default function SendEmailButton({
   successMessage,
   failureMessage,
   disabled,
+  customisable,
+  numEmails,
+  emailContext,
   ...buttonProps
 }: Props) {
   const [isSending, setIsSending] = useState(false);
+  const [isCustomising, setIsCustomising] = useState(false);
   const [result, setResult] = useState<SendEmailResult | null>(null);
   const t = useTranslations('SendEmailButton');
 
-  const onClick = async () => {
-    if (isSending) {
-      return;
-    }
-    setIsSending(true);
-    try {
-      const result = await sendEmail();
-      setResult(result);
-    } catch (error) {
-      setResult({
-        status: 'failed',
-        error: error instanceof Error ? error.message : String(error)
-      });
-    } finally {
-      setIsSending(false);
-    }
-  };
+  const doSend = !customisable
+    ? async (e: React.MouseEvent<HTMLButtonElement>) => {
+        if (isSending) {
+          return;
+        }
+        setIsSending(true);
+        try {
+          const result = await sendEmail();
+          setResult(result);
+        } catch (error) {
+          setResult({
+            status: 'failed',
+            error: error instanceof Error ? error.message : String(error)
+          });
+        } finally {
+          setIsSending(false);
+        }
+      }
+    : undefined;
+
+  const doCustomisedSend = customisable
+    ? async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (isSending) {
+          return;
+        }
+        const formData = new FormData(e.currentTarget);
+        const subject = formData.get('email-subject');
+        const body = formData.get('email-body');
+        const includeShifts = formData.get('include-shifts') === 'on';
+        if (typeof subject !== 'string' || typeof body !== 'string') {
+          setResult({
+            status: 'failed',
+            error: 'Invalid form data'
+          });
+          return;
+        }
+        const customisation: EmailCustomisation = {
+          subject,
+          body,
+          includeShifts
+        };
+        setIsSending(true);
+        try {
+          const result = await sendEmail(customisation);
+          setResult(result);
+        } catch (error) {
+          setResult({
+            status: 'failed',
+            error: error instanceof Error ? error.message : String(error)
+          });
+        } finally {
+          setIsSending(false);
+          setIsCustomising(false);
+        }
+      }
+    : undefined;
 
   return (
     <>
-      <Button onClick={onClick} disabled={disabled || isSending} {...buttonProps} />
+      {/* Button */}
+      <Button
+        onClick={customisable ? () => setIsCustomising(true) : doSend}
+        disabled={disabled || isSending}
+        {...buttonProps}
+      />
+
+      {/* Customisation dialog */}
+      {customisable && (
+        <Dialog.Root open={isCustomising} onOpenChange={setIsCustomising}>
+          <Dialog.Content>
+            <Dialog.Title>{t('notifyAll')}</Dialog.Title>
+            <Dialog.Description>
+              {t('notifyAllDescription', { numEmails, emailContext })}
+            </Dialog.Description>
+            <form onSubmit={doCustomisedSend}>
+              <Flex direction="column" gap="3" mt="4">
+                <FormField ariaId="email-subject" name={t('emailSubject')}>
+                  <TextField.Root
+                    required
+                    name="email-subject"
+                    placeholder={t('emailSubject')}
+                    aria-labelledby="email-subject"
+                  />
+                </FormField>
+                <FormField ariaId="email-body" name={t('emailBody')}>
+                  <TextArea
+                    required
+                    name="email-body"
+                    placeholder={t('emailBody')}
+                    aria-labelledby="email-body"
+                    size="3"
+                    resize="vertical"
+                  />
+                </FormField>
+                <FormField ariaId="include-shifts" name={t('includeShifts')}>
+                  <Checkbox
+                    style={{ alignSelf: 'flex-start' }}
+                    name="include-shifts"
+                    aria-labelledby="include-shifts"
+                    defaultChecked={false}
+                  />
+                </FormField>
+              </Flex>
+
+              <Flex gap="3" mt="4" justify="end">
+                <Dialog.Close>
+                  <Button variant="soft" color="gray">
+                    {t('cancel')}
+                  </Button>
+                </Dialog.Close>
+                <Button type="submit">{t('send', { numEmails })}</Button>
+              </Flex>
+            </form>
+          </Dialog.Content>
+        </Dialog.Root>
+      )}
+
+      {/* Confirmation dialog */}
       <Dialog.Root open={result !== null} onOpenChange={() => setResult(null)}>
         <Dialog.Content>
           <Dialog.Title>{result?.status === 'failed' ? failureTitle : successTitle}</Dialog.Title>

--- a/src/ui/send-email-button/index.tsx
+++ b/src/ui/send-email-button/index.tsx
@@ -81,11 +81,17 @@ export default function SendEmailButton({
         const subject = formData.get('email-subject');
         const body = formData.get('email-body');
         const includeShifts = formData.get('include-shifts') === 'on';
-        if (typeof subject !== 'string' || typeof body !== 'string') {
+        if (
+          typeof subject !== 'string' ||
+          typeof body !== 'string' ||
+          subject.trim() === '' ||
+          body.trim() === ''
+        ) {
           setResult({
             status: 'failed',
             error: 'Invalid form data'
           });
+          setIsCustomising(false);
           return;
         }
         const customisation: EmailCustomisation = {

--- a/src/ui/send-email-button/index.tsx
+++ b/src/ui/send-email-button/index.tsx
@@ -53,7 +53,7 @@ export default function SendEmailButton({
 
   const doSend = !customisable
     ? async (e: React.MouseEvent<HTMLButtonElement>) => {
-        if (isSending) {
+        if (isSending || numEmails === 0) {
           return;
         }
         setIsSending(true);
@@ -74,7 +74,7 @@ export default function SendEmailButton({
   const doCustomisedSend = customisable
     ? async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
-        if (isSending) {
+        if (isSending || numEmails === 0) {
           return;
         }
         const formData = new FormData(e.currentTarget);
@@ -120,7 +120,7 @@ export default function SendEmailButton({
       {/* Button */}
       <Button
         onClick={customisable ? () => setIsCustomising(true) : doSend}
-        disabled={disabled || isSending}
+        disabled={disabled || isSending || numEmails === 0}
         {...buttonProps}
       />
 

--- a/src/ui/send-email-button/index.tsx
+++ b/src/ui/send-email-button/index.tsx
@@ -171,7 +171,9 @@ export default function SendEmailButton({
                     {t('cancel')}
                   </Button>
                 </Dialog.Close>
-                <Button type="submit">{t('send', { numEmails })}</Button>
+                <Button disabled={isSending} type="submit">
+                  {t('send', { numEmails })}
+                </Button>
               </Flex>
             </form>
           </Dialog.Content>

--- a/src/ui/volunteer-filters/index.tsx
+++ b/src/ui/volunteer-filters/index.tsx
@@ -49,7 +49,10 @@ export default function VolunteerFilters({ withFilters = [] }: Props) {
   return (
     <Flex direction="column" gap="2">
       {hasFilter.has('searchQuery') && (
-        <SearchBar onChange={onFilterChange.bind(null, 'searchQuery')} />
+        <SearchBar
+          defaultValue={currentFilters.searchQuery}
+          onChange={onFilterChange.bind(null, 'searchQuery')}
+        />
       )}
       {showFilterPanel && (
         <Flex direction="column" gap="2">


### PR DESCRIPTION
Adds a 'Notify Volunteers' button to the Team Volunteers and Event Shifts pages.
The button provides a form that allows admins, organisers, and leads to send custom emails to all volunteers on the related page, with the option of including a list of the volunteer's shifts.