### PR TITLE
Feature: support multiple qualifications per shift

### DIFF
--- a/db/scripts/v018_allow_multiple_qualifications.sql
+++ b/db/scripts/v018_allow_multiple_qualifications.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "requirement"
+  DROP CONSTRAINT IF EXISTS "requirement_shiftId_key";
+
+ALTER TABLE "requirement"
+  ADD CONSTRAINT "requirement_shiftId_qualificationId_key"
+  UNIQUE ("shiftId", "qualificationId");

--- a/src/app/my-shifts/page.tsx
+++ b/src/app/my-shifts/page.tsx
@@ -13,6 +13,7 @@ import { Share2Icon, EnvelopeClosedIcon } from '@radix-ui/react-icons';
 import { Button, Flex, Heading } from '@radix-ui/themes';
 import { getTranslations } from 'next-intl/server';
 import { revalidatePath } from 'next/cache';
+import { getQualificationsForEvent } from '@/service/qualification-service';
 
 const PAGE_KEY = 'MyShiftsPage';
 
@@ -30,6 +31,7 @@ export default async function MyShifts() {
     event.id
   );
   const teams = await getTeamsForEvent(event.id);
+  const qualifications = await getQualificationsForEvent(event.id);
   const showEmailButton =
     process.env.NODE_ENV === 'development' ||
     process.env.USE_EMAIL_QUEUE === 'true' ||
@@ -91,6 +93,7 @@ export default async function MyShifts() {
         teams={teams}
         shifts={shifts}
         shiftVolunteers={shiftVolunteers}
+        qualifications={qualifications}
         onCancelShift={onCancelShift}
       />
     </Flex>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,7 @@ import { getVolunteersForShifts } from '@/service/user-service';
 import { getPermissionsProfile } from '@/utils/permissions';
 import { ArrowRightIcon } from '@radix-ui/react-icons';
 import TeamCard from '@/ui/team-card';
+import { getQualificationsForEvent } from '@/service/qualification-service';
 
 const PAGE_KEY = 'DashboardPage';
 
@@ -42,6 +43,7 @@ export default async function DashboardPage() {
   const totalHours = shifts.reduce((sum, shift) => sum + shift.durationHours, 0);
   const upcomingShifts = shifts.slice(0, 2);
   const teams = await getTeamsForEvent(event.id);
+  const qualifications = await getQualificationsForEvent(event.id);
   const upcomingShiftVolunteers = await getVolunteersForShifts(
     upcomingShifts.map((s) => s.id),
     permissionsProfile,
@@ -119,6 +121,7 @@ export default async function DashboardPage() {
             event={event}
             teams={teams}
             shiftVolunteers={upcomingShiftVolunteers}
+            qualifications={qualifications}
           />
         </Flex>
       )}

--- a/src/app/shifts/page.tsx
+++ b/src/app/shifts/page.tsx
@@ -13,6 +13,7 @@ import { Share2Icon, EnvelopeClosedIcon } from '@radix-ui/react-icons';
 import { Button, Flex, Heading } from '@radix-ui/themes';
 import { getTranslations } from 'next-intl/server';
 import { notFound } from 'next/navigation';
+import { getQualificationsForEvent } from '@/service/qualification-service';
 
 const PAGE_KEY = 'EventShiftsPage';
 
@@ -51,6 +52,7 @@ export default async function EventShifts() {
     {}
   );
   const teams = await getTeamsForEvent(event.id);
+  const qualifications = await getQualificationsForEvent(event.id);
   const emailableVolunteers = deduplicateBy(
     Object.values(shiftVolunteers).flat(),
     ({ id }) => id
@@ -104,6 +106,7 @@ export default async function EventShifts() {
         teams={teams}
         shifts={shifts}
         shiftVolunteers={shiftVolunteers}
+        qualifications={qualifications}
       />
     </Flex>
   );

--- a/src/app/team/[teamSlug]/page.tsx
+++ b/src/app/team/[teamSlug]/page.tsx
@@ -152,11 +152,18 @@ export default async function TeamPage({ params, searchParams }: PageProps<`/tea
       throw new Error('Shift does not belong to this team');
     }
 
-    if (shift.requirement) {
-      const qualifications = await getQualificationsForUser(permissions.userId, event.id);
-      const hasRequiredQualification = qualifications.some((q) => q.id === shift.requirement);
-      if (!hasRequiredQualification) {
-        throw new Error('User does not have the required qualification for this shift');
+    if (shift.requirements.length > 0) {
+      const userQualifications = await getQualificationsForUser(permissions.userId, event.id);
+      const userQualificationIds = new Set(
+        userQualifications.map((qualification) => qualification.id)
+      );
+
+      const hasAllRequiredQualifications = shift.requirements.every((qualificationId) =>
+        userQualificationIds.has(qualificationId)
+      );
+
+      if (!hasAllRequiredQualifications) {
+        throw new Error('User does not have all required qualifications for this shift');
       }
     }
 

--- a/src/service/shift-service.ts
+++ b/src/service/shift-service.ts
@@ -97,7 +97,7 @@ export const getShiftById = cache(async (shiftId: ShiftId): Promise<ShiftInfo | 
   if (result.rows.length === 0) {
     return null;
   }
-  return rowsToShift(result.rows)[0];
+  return rowsToShifts(result.rows)[0];
 });
 
 /**

--- a/src/service/shift-service.ts
+++ b/src/service/shift-service.ts
@@ -40,7 +40,7 @@ const rowToShift = (row: any): ShiftInfo => ({
   minVolunteers: row.minVolunteers,
   maxVolunteers: row.maxVolunteers,
   isActive: row.isActive,
-  requirement: row.qualificationId || undefined
+  requirements: []
 });
 
 const rowsToShifts = (rows: any[]): ShiftInfo[] => {
@@ -48,14 +48,18 @@ const rowsToShifts = (rows: any[]): ShiftInfo[] => {
 
   rows.forEach((row) => {
     if (!shiftsMap.has(row.id)) {
-      shiftsMap.set(row.id, rowToShift(row));
+      const shift = rowToShift(row);
+      shift.requirements = [];
+      shiftsMap.set(row.id, shift);
     }
 
     const shift = shiftsMap.get(row.id)!;
 
-    if (row.qualificationId) {
-      // Right now, we only support one requirement per shift
-      shift.requirement = row.qualificationId;
+     if (
+      row.qualificationId &&
+      !shift.requirements.includes(row.qualificationId)
+    ) {
+      shift.requirements.push(row.qualificationId);
     }
   });
 
@@ -93,7 +97,7 @@ export const getShiftById = cache(async (shiftId: ShiftId): Promise<ShiftInfo | 
   if (result.rows.length === 0) {
     return null;
   }
-  return rowToShift(result.rows[0]);
+  return rowsToShift(result.rows)[0];
 });
 
 /**
@@ -191,6 +195,27 @@ export const getShiftsForEvent = cache(async (eventId: EventId): Promise<ShiftIn
   return rowsToShifts(result.rows);
 });
 
+//Helper for inserting requirements
+const insertShiftRequirements = async (
+  db: PoolClient | typeof pool,
+  shiftId: ShiftId,
+  requirements: QualificationId[] = []
+) => {
+  for (const qualificationId of requirements) {
+    await db.query(
+      `
+      INSERT INTO requirement (
+        "shiftId",
+        "qualificationId"
+      )
+      VALUES ($1, $2)
+      ON CONFLICT ("shiftId", "qualificationId") DO NOTHING
+      `,
+      [shiftId, qualificationId]
+    );
+  }
+};
+
 /**
  * Creates a new shift in the database.
  * @param shift - The shift data, excluding the ID.
@@ -237,18 +262,10 @@ export const createShift = async (
     ]
   );
   const newShift = rowToShift(result.rows[0]);
-  if (shift.requirement) {
-    await db.query(
-      `
-      INSERT INTO requirement (
-        "shiftId",
-        "qualificationId"
-      ) VALUES ($1, $2)
-      `,
-      [newShift.id, shift.requirement]
-    );
-    newShift.requirement = shift.requirement;
-  }
+
+  await insertShiftRequirements(db, newShift.id, shift.requirements);
+  newShift.requirements = shift.requirements ?? [];
+
   console.info('Created new shift:', newShift);
   return newShift;
 };
@@ -295,33 +312,21 @@ export const updateShift = async (shift: ShiftInfo, client?: PoolClient): Promis
       shift.isActive
     ]
   );
+
   const updatedShift = rowToShift(result.rows[0]);
-  if (shift.requirement) {
-    // We currently only support one requirement per shift, so we can use an upsert to simplify logic
-    await db.query(
-      `
-      INSERT INTO requirement (
-        "shiftId",
-        "qualificationId"
-      ) VALUES ($1, $2)
-      ON CONFLICT ("shiftId")
-      DO UPDATE SET
-        "qualificationId" = EXCLUDED."qualificationId",
-        "updatedAt" = NOW()
-      `,
-      [updatedShift.id, shift.requirement]
-    );
-    updatedShift.requirement = shift.requirement;
-  } else {
-    // If no requirement is provided, delete any existing requirement for this shift
-    await db.query(
-      `
-      DELETE FROM requirement
-      WHERE "shiftId" = $1
-      `,
-      [updatedShift.id]
-    );
-  }
+
+  await db.query(
+    `
+    DELETE FROM requirement
+    WHERE "shiftId" = $1
+    `,
+    [updatedShift.id]
+  );
+
+  await insertShiftRequirements(db, updatedShift.id, shift.requirements);
+
+  updatedShift.requirements = shift.requirements ?? [];
+
   console.info('Updated shift:', updatedShift);
   return updatedShift;
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -122,7 +122,7 @@ declare global {
     durationHours: number;
     minVolunteers: number;
     maxVolunteers: number;
-    requirement?: QualificationId;
+    requirements: QualificationId[];
   }
 
   interface TeamFilters {

--- a/src/ui/shift-card/index.test.tsx
+++ b/src/ui/shift-card/index.test.tsx
@@ -32,7 +32,7 @@ describe('ShiftCard', () => {
     durationHours: 4,
     maxVolunteers: 10,
     minVolunteers: 2,
-    requirement: 'qualification-id'
+    requirements: ['qualification-id']
   };
   const mockQualification = {
     id: 'qualification-id',
@@ -63,16 +63,16 @@ describe('ShiftCard', () => {
     expect(screen.getByText('min: 2')).toBeInTheDocument();
   });
 
-  it('shows the qualification requirement when present', () => {
+  it('shows required qualifications when present', () => {
     render(
-      <ShiftCard shift={mockShift} qualification={mockQualification} volunteers={mockVolunteers} />
+      <ShiftCard shift={mockShift} qualifications={[mockQualification]} volunteers={mockVolunteers} />
     );
     const badge = screen.getByText('requires: First Aid');
     expect(badge).toBeInTheDocument();
     expect(badge).toHaveAttribute('href', getQualificationDetailsPath(mockQualification.id));
   });
 
-  it('does not show qualification requirement when not present', () => {
+  it('does not show required qualifications when none are present', () => {
     const mockShiftWithoutRequirement = {
       id: 'shift-id',
       teamId: 'team-id',
@@ -82,7 +82,8 @@ describe('ShiftCard', () => {
       startTime: '08:00',
       durationHours: 4,
       maxVolunteers: 10,
-      minVolunteers: 2
+      minVolunteers: 2,
+      requirements: []
     };
     render(<ShiftCard shift={mockShiftWithoutRequirement} volunteers={mockVolunteers} />);
 
@@ -129,35 +130,35 @@ describe('ShiftCard', () => {
 
   test.each<{
     isFull: boolean;
-    requirement: QualificationInfo | null;
+    qualifications: QualificationInfo[];
     isQualified: boolean;
     signupError: string | null;
   }>([
-    { isFull: false, requirement: null, isQualified: false, signupError: null },
-    { isFull: true, requirement: null, isQualified: false, signupError: 'full' },
+    { isFull: false, qualifications: [], isQualified: false, signupError: null },
+    { isFull: true, qualifications: [], isQualified: false, signupError: 'full' },
     {
       isFull: false,
-      requirement: mockQualification,
+      qualifications: [mockQualification],,
       isQualified: false,
       signupError: mockQualification.errorMessage
     },
-    { isFull: false, requirement: mockQualification, isQualified: true, signupError: null },
-    { isFull: true, requirement: mockQualification, isQualified: false, signupError: 'full' },
-    { isFull: true, requirement: mockQualification, isQualified: true, signupError: 'full' }
+    { isFull: false, qualifications: [mockQualification], isQualified: true, signupError: null },
+    { isFull: true, qualifications: [mockQualification], isQualified: false, signupError: 'full' },
+    { isFull: true, qualifications: [mockQualification], isQualified: true, signupError: 'full' }
   ])(
     'renders the signup button when onSignup is provided',
-    ({ isFull, requirement, isQualified, signupError }) => {
+    ({ isFull, qualifications, isQualified, signupError }) => {
       const onSignupMock = jest.fn();
       const shift = {
         ...mockShift,
         maxVolunteers: isFull ? mockVolunteers.length : mockShift.maxVolunteers,
-        requirement: requirement ? requirement.id : undefined
+        requirements: qualifications.map((qualification) => qualification.id)
       };
       render(
         <ShiftCard
           shift={shift}
           volunteers={mockVolunteers}
-          qualification={requirement || undefined}
+          qualifications={qualifications}
           isQualified={isQualified}
           onSignup={onSignupMock}
         />

--- a/src/ui/shift-card/index.tsx
+++ b/src/ui/shift-card/index.tsx
@@ -21,7 +21,7 @@ import NextLink from 'next/link';
 interface Props {
   shift: ShiftInfo;
   volunteers: VolunteerInfo[];
-  qualification?: QualificationInfo;
+  qualifications?: QualificationInfo[];
   isQualified?: boolean;
   collapsible?: boolean;
   onEdit?: () => void;
@@ -48,7 +48,7 @@ export default function ShiftCard({
   shift,
   date,
   volunteers,
-  qualification,
+  qualifications = [],
   onEdit,
   onCopy,
   onSignup,
@@ -69,17 +69,13 @@ export default function ShiftCard({
     ? new Date(startTime.getTime() + shift.durationHours * 60 * 60 * 1000)
     : addHoursToTimeString(shift.startTime, shift.durationHours);
   const volunteerCount = volunteers.length;
-  const requirementLabel =
-    shift.requirement && qualification && qualification.id === shift.requirement
-      ? qualification.name
-      : null;
   const [isExpanded, setIsExpanded] = useState(!collapsible);
 
   const isFull = volunteerCount >= shift.maxVolunteers;
   const cantSignupMessage = isFull
     ? t('full')
-    : shift.requirement && !isQualified
-      ? qualification?.errorMessage
+    : qualifications.length > 0 && !isQualified
+      ? qualifications.map((qualification) => qualification.errorMessage).join('\n')
       : undefined;
   const canSignup = !cantSignupMessage;
   const hasButtons = onSignup || onCancel;
@@ -114,13 +110,13 @@ export default function ShiftCard({
             >
               <Flex direction={{ initial: 'column', sm: 'row' }} flexGrow="1" gap="3" justify="end">
                 <Flex direction="row" gap="2" align="center" wrap="wrap">
-                  {requirementLabel && (
-                    <Badge color="yellow" asChild>
-                      <NextLink href={getQualificationDetailsPath(shift.requirement!)}>
-                        {t('requires')}: {requirementLabel}
+                  {qualifications.map((qualification) => (
+                    <Badge key={qualification.id} color="yellow" asChild>
+                      <NextLink href={getQualificationDetailsPath(qualification.id)}>
+                        {t('requires')}: {qualification.name}
                       </NextLink>
                     </Badge>
-                  )}
+                  ))}
                   <Flex direction="row" gap="2" align="center" wrap="wrap">
                     <Badge color="gray">
                       {t('max')}: {shift.maxVolunteers}

--- a/src/ui/shift-dialog/index.test.tsx
+++ b/src/ui/shift-dialog/index.test.tsx
@@ -45,7 +45,7 @@ describe('ShiftDialog', () => {
       durationHours: 4,
       minVolunteers: 2,
       maxVolunteers: 5,
-      requirement: 'qualification-1'
+      requirements: ['qualification-1']
     };
 
     const { getByText, getByRole, getByDisplayValue } = render(

--- a/src/ui/shift-dialog/index.tsx
+++ b/src/ui/shift-dialog/index.tsx
@@ -180,22 +180,26 @@ export default function ShiftDialog({
             name={t('requirements')}
             description={t('requirementsDescription')}
           >
-            <Select.Root name="requirement" defaultValue={editing?.requirement ?? 'null'}>
-              <Select.Trigger aria-labelledby="shift-requirements" />
-              <Select.Content>
-                <Select.Group>
-                  <Select.Item value="null">{t('none')}</Select.Item>
-                </Select.Group>
-                <Select.Separator />
-                <Select.Group>
-                  {qualificationOptions.map((q) => (
-                    <Select.Item key={q.id} value={q.id}>
-                      {q.name}
-                    </Select.Item>
-                  ))}
-                </Select.Group>
-              </Select.Content>
-            </Select.Root>
+            <Flex direction="column" gap="2" role="group" aria-labelledby="shift-requirements">
+              {qualificationOptions.length === 0 && (
+                <Text size="2" color="gray">
+                  {t('none')}
+                </Text>
+              )}
+
+              {qualificationOptions.map((q) => (
+                <Text as="label" key={q.id} size="2">
+                  <Flex gap="2" align="center">
+                    <Checkbox
+                      name="requirements"
+                      value={q.id}
+                      defaultChecked={editing?.requirements?.includes(q.id) ?? false}
+                    />
+                    {q.name}
+                  </Flex>
+                </Text>
+              ))}
+            </Flex>
           </FormField>
         </Flex>
         <Flex gap="4" mt="auto" py="4">

--- a/src/ui/shift-list/index.test.tsx
+++ b/src/ui/shift-list/index.test.tsx
@@ -47,7 +47,7 @@ const mockShifts: ShiftInfo[] = [
     eventDay: 0,
     startTime: '09:00',
     durationHours: 4,
-    requirement: 'qual1',
+    requirements: ['qual1'],
     isActive: true,
     minVolunteers: 1,
     maxVolunteers: 3
@@ -169,17 +169,22 @@ describe('ShiftList', () => {
     props.shifts.forEach((shift, i) => {
       const showSignup = props.onSignup && props.userShifts && !props.userShifts.has(shift.id);
       const showCancel = props.onCancel && props.userShifts && props.userShifts.has(shift.id);
-      const isQualified = shift.requirement
-        ? props.userQualifications
-          ? props.userQualifications.has(shift.requirement)
-          : false
-        : true;
+      const isQualified =
+        shift.requirements.length === 0 ||
+        Boolean(
+          props.userQualifications &&
+            shift.requirements.every((qualificationId) =>
+              props.userQualifications!.has(qualificationId)
+            )
+        );
       expect(screen.getByTestId(`shift-card:${shift.id}`)).toBeInTheDocument();
       expect(mockShiftCard).toHaveBeenNthCalledWith(
         i + 1,
         expect.objectContaining({
           shift,
-          qualification: mockQualificationMap.get(shift.requirement ?? ''),
+          qualifications: shift.requirements
+            .map((qualificationId) => mockQualificationMap.get(qualificationId))
+            .filter((qualification): qualification is QualificationInfo => Boolean(qualification)),
           volunteers: props.shiftVolunteers[shift.id] || [],
           onSignup: showSignup ? expect.any(Function) : undefined,
           onCancel: showCancel ? expect.any(Function) : undefined,

--- a/src/ui/shift-list/index.tsx
+++ b/src/ui/shift-list/index.tsx
@@ -96,28 +96,35 @@ export default function ShiftList({
         <DatedList
           items={shifts}
           getDate={(shift) => eventDayToDate(event.startDate, shift.eventDay)}
-          renderItem={(shift) => (
-            <ShiftCard
-              date={eventDayToDate(event.startDate, shift.eventDay)}
-              shift={shift}
-              qualification={
-                shift.requirement ? qualificationMap.get(shift.requirement) : undefined
-              }
-              volunteers={shiftVolunteers[shift.id] || []}
-              key={shift.id}
-              onEdit={showEdit(shift) ? () => setEditingShift(shift) : undefined}
-              onCopy={canEdit ? () => setEditingShift({ ...shift, id: undefined }) : undefined}
-              onSignup={showSignup(shift) ? () => onSignup!(shift.id) : undefined}
-              onCancel={showCancel(shift) ? () => onCancel!(shift.id) : undefined}
-              isQualified={
-                shift.requirement
-                  ? userQualifications
-                    ? userQualifications.has(shift.requirement)
-                    : false
-                  : true
-              }
-            />
-          )}
+          renderItem={(shift) => {
+            const requiredQualifications = shift.requirements
+              .map((qualificationId) => qualificationMap.get(qualificationId))
+              .filter((qualification): qualification is QualificationInfo => Boolean(qualification));
+
+            const isQualified =
+              shift.requirements.length === 0 ||
+              Boolean(
+                userQualifications &&
+                  shift.requirements.every((qualificationId) =>
+                    userQualifications.has(qualificationId)
+                  )
+              );
+
+            return (
+              <ShiftCard
+                date={eventDayToDate(event.startDate, shift.eventDay)}
+                shift={shift}
+                qualifications={requiredQualifications}
+                volunteers={shiftVolunteers[shift.id] || []}
+                key={shift.id}
+                onEdit={showEdit(shift) ? () => setEditingShift(shift) : undefined}
+                onCopy={canEdit ? () => setEditingShift({ ...shift, id: undefined }) : undefined}
+                onSignup={showSignup(shift) ? () => onSignup!(shift.id) : undefined}
+                onCancel={showCancel(shift) ? () => onCancel!(shift.id) : undefined}
+                isQualified={isQualified}
+              />
+            );
+          }}
         />
       </Flex>
       {canEdit && (

--- a/src/ui/shift-overview-list/index.test.tsx
+++ b/src/ui/shift-overview-list/index.test.tsx
@@ -44,7 +44,8 @@ describe('ShiftOverviewList', () => {
       startTime: '',
       durationHours: 0,
       minVolunteers: 0,
-      maxVolunteers: 0
+      maxVolunteers: 0,
+      requirements: []
     },
     {
       id: 'shift2',
@@ -55,7 +56,8 @@ describe('ShiftOverviewList', () => {
       startTime: '',
       durationHours: 0,
       minVolunteers: 0,
-      maxVolunteers: 0
+      maxVolunteers: 0,
+      requirements: []
     },
     {
       id: 'shift3',
@@ -66,7 +68,8 @@ describe('ShiftOverviewList', () => {
       startTime: '',
       durationHours: 0,
       minVolunteers: 0,
-      maxVolunteers: 0
+      maxVolunteers: 0,
+      requirements: []
     }
   ];
 
@@ -87,6 +90,7 @@ describe('ShiftOverviewList', () => {
         teams={mockTeams}
         shifts={mockShifts}
         shiftVolunteers={mockShiftVolunteers}
+        qualifications={[]}
       />
     );
 
@@ -99,6 +103,7 @@ describe('ShiftOverviewList', () => {
     expect(mockShiftCard).toHaveBeenCalledWith(
       expect.objectContaining({
         shift: mockShifts[0],
+        qualifications: [],
         volunteers: mockShiftVolunteers['shift1'],
         collapsible: true
       }),
@@ -107,6 +112,7 @@ describe('ShiftOverviewList', () => {
     expect(mockShiftCard).toHaveBeenCalledWith(
       expect.objectContaining({
         shift: mockShifts[1],
+        qualifications: [],
         volunteers: mockShiftVolunteers['shift2'],
         collapsible: true
       }),
@@ -115,6 +121,7 @@ describe('ShiftOverviewList', () => {
     expect(mockShiftCard).toHaveBeenCalledWith(
       expect.objectContaining({
         shift: mockShifts[2],
+        qualifications: [],
         volunteers: mockShiftVolunteers['shift3'],
         collapsible: true
       }),
@@ -124,7 +131,7 @@ describe('ShiftOverviewList', () => {
 
   it('renders empty state when no shifts are provided', () => {
     render(
-      <ShiftOverviewList event={mockEvent} teams={mockTeams} shifts={[]} shiftVolunteers={{}} />
+      <ShiftOverviewList event={mockEvent} teams={mockTeams} shifts={[]} shiftVolunteers={{}} qualifications={[]} />
     );
 
     // Check that no team names or shifts are rendered

--- a/src/ui/shift-overview-list/index.tsx
+++ b/src/ui/shift-overview-list/index.tsx
@@ -16,6 +16,7 @@ interface Props {
   teams: TeamInfo[];
   shifts: ShiftInfo[];
   shiftVolunteers: Record<ShiftId, VolunteerInfo[]>;
+  qualifications: QualificationInfo[];
   onCancelShift?: (shiftId: ShiftId) => Promise<void>;
 }
 
@@ -24,11 +25,15 @@ export default function ShiftOverviewList({
   teams,
   shifts,
   shiftVolunteers,
+  qualifications,
   onCancelShift
 }: Props) {
   const teamNames = teams.reduce<Record<TeamId, string>>(
     (acc, team) => ({ ...acc, [team.id]: team.name }),
     {}
+  );
+  const qualificationMap = new Map(
+    qualifications.map((qualification) => [qualification.id, qualification])
   );
 
   const teamShiftsByDay = shifts.reduce<Record<number, Record<TeamId, ShiftInfo[]>>>(
@@ -53,16 +58,22 @@ export default function ShiftOverviewList({
                 {teamNames[teamId]}
               </Heading>
               <Flex direction="column" gap="2" mt="4">
-                {shifts.map((shift) => (
-                  <ShiftCard
-                    date={eventDayToDate(event.startDate, shift.eventDay)}
-                    shift={shift}
-                    volunteers={shiftVolunteers[shift.id] ?? []}
-                    key={shift.id}
-                    collapsible
-                    onCancel={onCancelShift?.bind(null, shift.id)}
-                  />
-                ))}
+                {shifts.map((shift) => {
+                  const requiredQualifications = shift.requirements
+                    .map((qualificationId) => qualificationMap.get(qualificationId))
+                    .filter((qualification): qualification is QualificationInfo => Boolean(qualification));
+                  return (
+                    <ShiftCard
+                      date={eventDayToDate(event.startDate, shift.eventDay)}
+                      shift={shift}
+                      qualifications={requiredQualifications}
+                      volunteers={shiftVolunteers[shift.id] ?? []}
+                      key={shift.id}
+                      collapsible
+                      onCancel={onCancelShift?.bind(null, shift.id)}
+                    />
+                  );
+                })}
               </Flex>
             </Card>
           ))}

--- a/src/validator/shift-validator.test.ts
+++ b/src/validator/shift-validator.test.ts
@@ -21,7 +21,7 @@ describe('validateNewShift', () => {
       minVolunteers: '2',
       maxVolunteers: '5',
       isActive: 'on',
-      requirement: 'qualification-id'
+      requirements: ['qualification-id']
     });
 
     const result = validateNewShift(formData);
@@ -35,7 +35,7 @@ describe('validateNewShift', () => {
       minVolunteers: 2,
       maxVolunteers: 5,
       isActive: true,
-      requirement: 'qualification-id'
+      requirements: ['qualification-id']
     });
   });
 
@@ -205,7 +205,7 @@ describe('validateNewShift', () => {
     expect(result.isActive).toBe(false);
   });
 
-  it('sets requirement to undefined if the value is "null"', () => {
+  it('sets requirements to empty array if none selected', () => {
     const formData = createFormData({
       teamId: 'team-123',
       title: 'Morning Shift',
@@ -214,13 +214,12 @@ describe('validateNewShift', () => {
       durationHours: '4',
       minVolunteers: '2',
       maxVolunteers: '5',
-      requirement: 'null',
       isActive: 'on'
     });
 
     const result = validateNewShift(formData);
 
-    expect(result.requirement).toBeUndefined();
+    expect(result.requirements).toEqual([]);
   });
 });
 

--- a/src/validator/shift-validator.ts
+++ b/src/validator/shift-validator.ts
@@ -81,7 +81,10 @@ export const validateNewShift = (data: FormData): Omit<ShiftInfo, 'id'> => {
   const isActive = isActiveStr === 'on';
 
   // The form submits the string "null" when no requirement is selected, so that will be our default
-  const requirement = data.get('requirement')?.toString() ?? 'null';
+  const requirements = data
+  .getAll('requirements')
+  .map((value) => value.toString())
+  .filter((value) => value && value.toLowerCase() !== 'null');
 
   const shift: Omit<ShiftInfo, 'id'> = {
     teamId,
@@ -91,10 +94,9 @@ export const validateNewShift = (data: FormData): Omit<ShiftInfo, 'id'> => {
     durationHours,
     minVolunteers,
     maxVolunteers,
-    isActive
+    isActive,
+    requirements
   };
-  if (requirement && requirement.toLowerCase() !== 'null') {
-    shift.requirement = requirement;
-  }
+
   return shift;
 };


### PR DESCRIPTION
## Summary
Adds support for multiple qualifications per shift.

## Changes
- DB: updated requirement constraint to allow multiple qualifications
- Backend: updated shift-service and types
- Validator: supports multiple requirements
- UI: updated shift dialog, card, list, overview
- Enforcement: requires all qualifications for signup
- Tests: updated across validator and UI

## Notes
This builds on the luna-bugs branch.